### PR TITLE
Bug fix: aria-* attributes don't work in firefox

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,11 +196,11 @@ However, certain attributes will be treated differently.
 
 ### `aria-*`
 
-An attribute starting with `aria-` will be passed to [the props module](https://github.com/snabbdom/snabbdom#the-props-module). Note that dashes will be converted to camel case.
+An attribute starting with `aria-` will be passed to [the attributes module](https://github.com/snabbdom/snabbdom#the-attributes-module).
 
 ```tsx
 <button aria-label="Send" />
-// { props: { ariaLabel: 'Send' } }
+// { attrs: { 'aria-label': 'Send' } }
 ```
 
 ### `data-*`

--- a/src/index.test.tsx
+++ b/src/index.test.tsx
@@ -95,8 +95,8 @@ describe(jsx, () => {
         expect(<div aria-label="Send" />).toStrictEqual({
             children: [],
             data: {
-                props: {
-                    ariaLabel: 'Send',
+                attrs: {
+                    'aria-label': 'Send',
                 },
             },
             elm: undefined,

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,12 +25,8 @@ const canonicalizeVNodeData = (orig: VNodeData): VNodeData => {
         if (key === '$attrs' || key === 'attrs') {
             data.attrs = Object.assign(v, data.attrs ?? {});
         } else if (key.startsWith('aria-')) {
-            const k = kebab2camel(key);
-            if (data.props === undefined) {
-                data.props = { [k]: v };
-            } else {
-                data.props[k] = v;
-            }
+            data.attrs ??= {};
+            data.attrs[key] = v;
         } else if (key === '$class' || key === 'class') {
             data.class = v;
         } else if (key === 'className' || key === 'id') {


### PR DESCRIPTION
## 原因と確認事項
`ariaXXX` プロパティはfirefoxでは未対応.
https://developer.mozilla.org/en-US/docs/Web/API/Element/ariaLabel

これが原因で `<div aria-label="hoge" />` のようなコードを書いてもfirefoxだと反映されないバグが発生していたので, `props` から `attrs` にmappingを変更し, ドキュメントとテストも修正した.
ChromeとFirefoxの最新版で正常に属性の追加/変更がされることを確認した.