### PR TITLE
th には scope や colspan を指定できます

### DIFF
--- a/src/jsx-runtime.ts
+++ b/src/jsx-runtime.ts
@@ -836,7 +836,7 @@ declare namespace Snabbdom {
     }
 
     namespace HTMLTableHeaderCellElement {
-        interface Props extends HTMLElement.Props {}
+        interface Props extends HTMLTableCellElement.Props {}
     }
 
     namespace HTMLTableRowElement {


### PR DESCRIPTION
https://github.com/herp-inc/herpism/pull/1364 の変更で、attribute table の最左列を `th` にして `scope="row"` にしたい。
ので、 `HTMLTableHeaderCellElement` の props 定義をよろしくする。