### PR TITLE
Handle nested svg and foreignObject elements

### DIFF
--- a/src/jsx-runtime.test.tsx
+++ b/src/jsx-runtime.test.tsx
@@ -1033,6 +1033,133 @@ describe('automatic runtime', () => {
         });
     });
 
+    test('nested SVG', () => {
+        expect(
+            <svg id="foo" className="wrapper" viewBox="25 25 50 50">
+                <circle id="baz" className="circle" cx="50" cy="50" r="20" />
+                <svg id="bar" className="inner" viewBox="1 2 3 4">
+                    <circle id="garply" className="round" cx="10" cy="20" r="30" />
+                </svg>
+                <svg viewBox="5 6 7 8">
+                    <circle id="ding" className="ball" cx="40" cy="50" r="60" />
+                </svg>
+                <foreignObject id="xyzzy" className="abc">
+                    <a href="quux"/>
+                </foreignObject>
+            </svg>
+        ).toStrictEqual({
+            children: [
+                {
+                    children: undefined,
+                    data: {
+                        attrs: {
+                            cx: '50',
+                            cy: '50',
+                            r: '20',
+                        },
+                        ns: 'http://www.w3.org/2000/svg',
+                    },
+                    elm: undefined,
+                    key: undefined,
+                    sel: 'circle#baz.circle',
+                    text: undefined,
+                },
+                {
+                    children: [
+                        {
+                            children: undefined,
+                            data: {
+                                attrs: {
+                                    cx: '10',
+                                    cy: '20',
+                                    r: '30',
+                                },
+                                ns: 'http://www.w3.org/2000/svg',
+                            },
+                            elm: undefined,
+                            key: undefined,
+                            sel: 'circle#garply.round',
+                            text: undefined,
+                        }
+                    ],
+                    data: {
+                        attrs: {
+                            viewBox: '1 2 3 4',
+                        },
+                        ns: 'http://www.w3.org/2000/svg',
+                    },
+                    elm: undefined,
+                    key: undefined,
+                    sel: 'svg#bar.inner',
+                    text: undefined,
+                },
+                {
+                    children: [
+                        {
+                            children: undefined,
+                            data: {
+                                attrs: {
+                                    cx: '40',
+                                    cy: '50',
+                                    r: '60',
+                                },
+                                ns: 'http://www.w3.org/2000/svg',
+                            },
+                            elm: undefined,
+                            key: undefined,
+                            sel: 'circle#ding.ball',
+                            text: undefined,
+                        }
+                    ],
+                    data: {
+                        attrs: {
+                            viewBox: '5 6 7 8',
+                        },
+                        ns: 'http://www.w3.org/2000/svg',
+                    },
+                    elm: undefined,
+                    key: undefined,
+                    sel: 'svg',
+                    text: undefined,
+                },
+                {
+                    children: [
+                        {
+                            children: undefined,
+                            data: {
+                                props: {
+                                    href: 'quux',
+                                }
+                            },
+                            elm: undefined,
+                            key: undefined,
+                            sel: 'a',
+                            text: undefined,
+                        }
+                    ],
+                    data: {
+                        attrs: {},
+                        ns: 'http://www.w3.org/2000/svg',
+                    },
+                    elm: undefined,
+                    key: undefined,
+                    sel: 'foreignObject#xyzzy.abc',
+                    text: undefined,
+                },
+            ],
+            data: {
+                attrs: {
+                    viewBox: '25 25 50 50',
+                },
+                ns: 'http://www.w3.org/2000/svg',
+            },
+            elm: undefined,
+            key: undefined,
+            sel: 'svg#foo.wrapper',
+            text: undefined,
+        });
+    });
+
     test('popover API', () => {
         expect(
             <>

--- a/src/jsx-runtime.ts
+++ b/src/jsx-runtime.ts
@@ -1205,6 +1205,14 @@ const canonicalizeVNodeData = (orig: VNodeData): VNodeData => {
     return data;
 };
 
+const tagFromSel = (sel: String | undefined): String | undefined => {
+    if (!sel) {
+        return undefined;
+    } else {
+        return sel.split(/[.#]/)[0];
+    }
+}
+
 const considerSVG = (vnode: VNode): VNode => {
     const { props: { className = undefined, ...attrs } = {}, ...data } = vnode.data ?? {};
 
@@ -1215,7 +1223,11 @@ const considerSVG = (vnode: VNode): VNode => {
             attrs,
             ns: 'http://www.w3.org/2000/svg',
         },
-        children: vnode.children?.map((child) => (typeof child === 'string' ? child : considerSVG(child))),
+        children: vnode.children?.map((child) =>
+            // Process children, but don't double-process nested svg elements that have already been processed,
+            // and don't process contents of foreignObject (which are not svg themselves).
+            (typeof child === 'string' || tagFromSel(child.sel) === 'svg' || tagFromSel(vnode.sel) === 'foreignObject'
+                ? child : considerSVG(child))),
     };
 };
 


### PR DESCRIPTION
snabbdom-jsx wasn’t correctly handling svg tags inside of svg tags. considerSVG was double-converting them, leading to an invalid DOM. Similarly, foreignObject inside of svg was getting converted incorrectly. This patch adds unit tests for both of these cases, and adds a check in considerSVG to avoid incorrect conversion.